### PR TITLE
fix: convert bookmarks from array to object on old sidecars

### DIFF
--- a/action.py
+++ b/action.py
@@ -124,6 +124,9 @@ def parse_sidecar_lua(sidecar_lua):
         decoded_lua = None
 
     if 'bookmarks' in decoded_lua:
+        if type(decoded_lua['bookmarks']) is list:
+            decoded_lua['bookmarks'] = {i+1: bookmark for i, bookmark in enumerate(decoded_lua['bookmarks'])}  # Starts from 1
+            
         debug_print('calculating first and last bookmark dates')
         bookmark_dates = [
             datetime.strptime(


### PR DESCRIPTION
Fixes #16 on v0.6.7 (latest) on the plugin.

Some sidecars store bookmarks as such:
```json
        "bookmarks": [
            {
                "chapter": "",
                "datetime": "2023-11-02 14:52:29",
                "highlighted": true,
                "page": "/html/body/p[1469]/text().59",
                "pos0": "/html/body/p[1469]/text().59",
                "pos1": "/html/body/p[1469]/text().73",
            }
        ]
```
Where bookmarks is an array instead of the standard object, preventing them from being parsed (list has no attribute values). To handle this, bookmarks in this format are converted to the regular format before being parsed.

