### PR TITLE
Remove quotes from integer object keys in Lua

### DIFF
--- a/action.py
+++ b/action.py
@@ -611,6 +611,13 @@ class KoreaderAction(InterfaceAction):
             }
         sidecar_dict = json.loads(sidecar_metadata)
         sidecar_lua = lua.encode(sidecar_dict)
+        # Lua -> JSON -> Lua conversion is lossy, because JSON does not support integer
+        # keys. This means that a key like [1] will end up as ["1"] after the round
+        # trip. The following regex strips the quotes from any Lua object key that consists of
+        # only digits. This is not entirely correct because it now converts keys with
+        # only digits that were originally string keys as well, but it doesn't seem that
+        # KOReader uses those.
+        sidecar_lua = re.sub(r'\["(\d+)"\]', r'[\1]', sidecar_lua)
         sidecar_lua_formatted = f"-- we can read Lua syntax here!\nreturn {sidecar_lua}\n"
         try:
             os.makedirs(os.path.dirname(path))


### PR DESCRIPTION
From https://github.com/harmtemolder/koreader-calibre-plugin/issues/28#issuecomment-2531791500:
> There is a fundamental problem with the current architecture. The Lua objects in the sidecar files are parsed and then encoded as JSON, and this operation is not lossless. Lua supports different types of object keys, while JSON only supports strings.
> 
> To give an example of where this behavior causes problems. Given some Lua object as follows.
> ```lua
> {
>   [5] = "value"
> }
> ```
> 
> This object will be stored as the following JSON object in Calibre.
> ```json
> {
>   "5": "value"
> }
> ```
> 
> However, the following Lua object leads to exactly the same JSON object in Calibre.
> ```lua
> {
>   ["5"] = "value"
> }
> ```
> 
> When restoring the JSON object back to a Lua object to put in the sidecar file, you can either choose to encode the key to `[5]` or `["5"]`. Before #52, the behavior was to encode JSON keys like `"<integer>"` to `[<integer>]` in Lua, but now they are always encoded to `["<integer>"]` in Lua. _Both options are ultimately wrong!_ However, the behavior before #52 was less problematic, since KOReader doesn't appear to use `["<integer>"]` keys in Lua, so the incorrect encoding was never encountered.

For now, this PR should revert to the behavior that is correct in most cases. I've done a quick check in the KOReader source to see if it ever uses string keys with the string only containing digits, but that does not appear to be the case.

This PR should also fix the issue described here: https://github.com/harmtemolder/koreader-calibre-plugin/issues/28#issuecomment-2353320898. @harmtemolder, could you verify whether it is working as expected for you?

Discussion on future direction should be moved to #58.