### PR TITLE
Added Configureable Option for Percentage Float

### DIFF
--- a/action.py
+++ b/action.py
@@ -939,11 +939,14 @@ class KoreaderAction(InterfaceAction):
 
                     # Map of progress_data keys to match each config key
                     progress_mapping = {
-                        'column_percent_read': progress_data['percentage'],
+                        'column_percent_read': progress_data['percentage'] if not CONFIG["checkbox_percent_read_100"] else progress_data['percentage']*100,
                         'column_percent_read_int': round(progress_data['percentage']*100),
                         'column_last_read_location': progress_data['progress']
                         # Device, Device ID, and timestamp could also be added
                     }
+                    # Change percentage to be human readable on summary screen
+                    if CONFIG["checkbox_percent_read_100"]:
+                        progress_data['percentage']*=100
 
                     # Dictionary to store values to be updated
                     keys_values_to_update = {}

--- a/config.py
+++ b/config.py
@@ -254,6 +254,11 @@ CUSTOM_COLUMN_DEFAULTS = {
 }
 
 CHECKBOXES = {  # Each entry in the below dict is keyed with config_name
+    'checkbox_percent_read_100': {
+        'config_label': 'Percent read column (float) range 0.0-100.0',
+        'config_tool_tip': 'Default the range is 0.0-1.0\n'
+        'Checking this option the float value is multiplied by 100 to be in range 0.0-100.0',
+    },
     'checkbox_sync_if_more_recent': {
         'config_label': 'Sync only if changes are more recent',
         'config_tool_tip': 'Sync book only if the metadata is more recent. Requires\n'
@@ -346,6 +351,7 @@ class ConfigWidget(QWidget):  # https://doc.qt.io/qt-5/qwidget.html
             )
 
         # Add custom checkboxes
+        layout.addLayout(self.add_checkbox('checkbox_percent_read_100'))
         layout.addLayout(self.add_checkbox('checkbox_sync_if_more_recent'))
         layout.addLayout(self.add_checkbox('checkbox_no_sync_if_finished'))
 


### PR DESCRIPTION
This is a bit subjective, however I have another plugin (Reading Goal) that tracks the reading progress. This plugin wants the reading progress in range 0-100.
I could use the int column for this, but on very large books a bit more accuracy is needed.

This patch allows the read percentage float to be configured to be in range of 0-100 instead of 0-1. This simply multiplies the value by 100 when being set.


Also very often it is checked if `read_percent < 100` which doesn't work for float in range 0.0-1.0
And as far as I know the official koreader progress sync server returns progress in range 0.0-1.0 too:
https://github.com/koreader/koreader-sync-server?tab=readme-ov-file#privacy-and-security