### PR TITLE
[ProgressSync] Added option to use fixed text and option to change status texts

### DIFF
--- a/action.py
+++ b/action.py
@@ -532,9 +532,9 @@ class KoreaderAction(InterfaceAction):
             current_read_percent = metadata.get(read_percent_key)
             current_status = metadata.get(status_key)
             current_status_enum = metadata.get(status_key_enum)
-            if current_read_percent is not None and current_read_percent >= 100 \
-                    or current_status is not None and current_status == reading_status_texts_complete \
-                    or current_status_enum is not None and current_status_enum == reading_status_texts_complete:
+            if (current_read_percent is not None and current_read_percent >= 100) \
+                    or (current_status is not None and current_status == reading_status_texts_complete) \
+                    or (current_status_enum is not None and current_status_enum == reading_status_texts_complete):
                 debug_print(f'book {book_id} was already finished')
                 return OperationStatus.SKIP, {
                     'result': 'skipped, book already finished',
@@ -548,12 +548,12 @@ class KoreaderAction(InterfaceAction):
                 new_read_percent = keys_values_to_update.get(read_percent_key)
                 current_status = metadata.get(status_key)
                 current_status_enum = metadata.get(status_key_enum)
-                if new_read_percent and \
-                        ((current_status is not None and current_status != reading_status_texts_abandoned) or \
-                         (current_status_enum is not None and current_status_enum != reading_status_texts_abandoned)):
-                    if new_read_percent > 0 and new_read_percent < 100 and \
-                        ((current_status is not None and current_status != reading_status_texts_reading) or \
-                         (current_status_enum is not None and current_status_enum != reading_status_texts_reading)):
+                if new_read_percent \
+                        and ((current_status is not None and current_status != reading_status_texts_abandoned) \
+                          or (current_status_enum is not None and current_status_enum != reading_status_texts_abandoned)):
+                    if new_read_percent > 0 and new_read_percent < 100 \
+                            and ((current_status is not None and current_status != reading_status_texts_reading) \
+                              or (current_status_enum is not None and current_status_enum != reading_status_texts_reading)):
                         if status_key:
                             debug_print(
                                 f'book {book_id} set column_status to {reading_status_texts_reading}')
@@ -565,9 +565,9 @@ class KoreaderAction(InterfaceAction):
                         status_bool_key = CONFIG['column_status_bool']
                         if status_bool_key:
                             keys_values_to_update[status_bool_key] = False
-                    elif new_read_percent >= 100 and \
-                        ((current_status is not None and current_status != reading_status_texts_complete) or \
-                         (current_status_enum is not None and current_status_enum != reading_status_texts_complete)):
+                    elif new_read_percent >= 100 \
+                            and ((current_status is not None and current_status != reading_status_texts_complete) \
+                              or (current_status_enum is not None and current_status_enum != reading_status_texts_complete)):
                         if status_key:
                             debug_print(
                                 f'book {book_id} set column_status to {reading_status_texts_complete}')
@@ -955,9 +955,9 @@ class KoreaderAction(InterfaceAction):
             metadata_status = metadata.get(status_key)
             metadata_status_enum = metadata.get(status_key_enum)
             metadata_read_percent = metadata.get(read_percent_key)
-            if (metadata_read_percent is None or metadata_read_percent < 100) and \
-               ((metadata_status is None or metadata_status == reading_status_texts_reading) or \
-                (metadata_status_enum is None or metadata_status_enum == reading_status_texts_reading)):
+            if (metadata_read_percent is None or metadata_read_percent < 100) \
+                   and ((metadata_status is None or metadata_status == reading_status_texts_reading) \
+                     or (metadata_status_enum is None or metadata_status_enum == reading_status_texts_reading)):
                 try:
                     url = f'{CONFIG["progress_sync_url"]}/syncs/progress/{md5_value}'
                     request = Request(url, headers=headers)

--- a/action.py
+++ b/action.py
@@ -490,6 +490,9 @@ class KoreaderAction(InterfaceAction):
         updateLog = {}
 
         read_percent_key = CONFIG['column_percent_read'] or CONFIG['column_percent_read_int']
+        reading_status_texts_reading = CONFIG['reading_status_texts_reading']
+        reading_status_texts_complete = CONFIG['reading_status_texts_complete']
+        reading_status_texts_abandoned = CONFIG['reading_status_texts_abandoned']
 
         # Check config to sync only if data is more recent
         if CONFIG['checkbox_sync_if_more_recent']:
@@ -524,34 +527,55 @@ class KoreaderAction(InterfaceAction):
 
         # Check config to sync only if the book is not yet finished
         status_key = CONFIG['column_status']
+        status_key_enum = CONFIG['column_status_enum']
         if CONFIG['checkbox_no_sync_if_finished']:
             current_read_percent = metadata.get(read_percent_key)
             current_status = metadata.get(status_key)
+            current_status_enum = metadata.get(status_key_enum)
             if current_read_percent is not None and current_read_percent >= 100 \
-                    or current_status is not None and current_status == "complete":
+                    or current_status is not None and current_status == reading_status_texts_complete \
+                    or current_status_enum is not None and current_status_enum == reading_status_texts_complete:
                 debug_print(f'book {book_id} was already finished')
                 return OperationStatus.SKIP, {
                     'result': 'skipped, book already finished',
                 }
 
         # Check and correct reading status if required
-        if status_key:
+        if status_key or status_key_enum:
             new_status = keys_values_to_update.get(status_key)
-            if not new_status:
+            new_status_enum = keys_values_to_update.get(status_key_enum)
+            if not new_status or not new_status_enum:
                 new_read_percent = keys_values_to_update.get(read_percent_key)
                 current_status = metadata.get(status_key)
-                if new_read_percent and current_status != "abandoned":
-                    if new_read_percent > 0 and new_read_percent < 100 and current_status != "reading":
-                        debug_print(
-                            f'book {book_id} set column_status to reading')
-                        keys_values_to_update[status_key] = "reading"
+                current_status_enum = metadata.get(status_key_enum)
+                if new_read_percent and \
+                        ((current_status is not None and current_status != reading_status_texts_abandoned) or \
+                         (current_status_enum is not None and current_status_enum != reading_status_texts_abandoned)):
+                    if new_read_percent > 0 and new_read_percent < 100 and \
+                        ((current_status is not None and current_status != reading_status_texts_reading) or \
+                         (current_status_enum is not None and current_status_enum != reading_status_texts_reading)):
+                        if status_key:
+                            debug_print(
+                                f'book {book_id} set column_status to {reading_status_texts_reading}')
+                            keys_values_to_update[status_key] = reading_status_texts_reading
+                        if status_key_enum:
+                            debug_print(
+                                f'book {book_id} set column_status_enum to {reading_status_texts_reading}')
+                            keys_values_to_update[status_key_enum] = reading_status_texts_reading
                         status_bool_key = CONFIG['column_status_bool']
                         if status_bool_key:
                             keys_values_to_update[status_bool_key] = False
-                    elif new_read_percent >= 100 and current_status != "complete":
-                        debug_print(
-                            f'book {book_id} set column_status to complete')
-                        keys_values_to_update[status_key] = "complete"
+                    elif new_read_percent >= 100 and \
+                        ((current_status is not None and current_status != reading_status_texts_complete) or \
+                         (current_status_enum is not None and current_status_enum != reading_status_texts_complete)):
+                        if status_key:
+                            debug_print(
+                                f'book {book_id} set column_status to {reading_status_texts_complete}')
+                            keys_values_to_update[status_key] = reading_status_texts_complete
+                        if status_key_enum:
+                            debug_print(
+                                f'book {book_id} set column_status_enum to {reading_status_texts_complete}')
+                            keys_values_to_update[status_key_enum] = reading_status_texts_complete
                         status_bool_key = CONFIG['column_status_bool']
                         if status_bool_key:
                             keys_values_to_update[status_bool_key] = True
@@ -878,13 +902,27 @@ class KoreaderAction(InterfaceAction):
             return None
 
         status_key = CONFIG['column_status']
+        status_key_enum = CONFIG['column_status_enum']
         read_percent_key = CONFIG['column_percent_read_int'] or CONFIG['column_percent_read']
-        if read_percent_key == '' or status_key == '':
+        if read_percent_key == '' or (status_key == '' and status_key_enum == ''):
             error_dialog(
                 self.gui,
                 'Failure',
-                'This feature needs a KOReader Progress (int or float) and Status Text column.\n'
+                'This feature needs a KOReader Progress (int or float) and Status Text column (text or fixed text).\n'
                 'Add those in plugin settings and try again.',
+                show=True,
+                show_copy_button=False
+            )
+            return None
+        reading_status_texts_reading = CONFIG['reading_status_texts_reading']
+        reading_status_texts_complete = CONFIG['reading_status_texts_complete']
+        reading_status_texts_abandoned = CONFIG['reading_status_texts_abandoned']
+        if reading_status_texts_reading == '' or reading_status_texts_complete == '' or reading_status_texts_abandoned == '':
+            error_dialog(
+                self.gui,
+                'Failure',
+                'This feature needs the reading status texts (reading, complete, abandoned) not to be empty.\n'
+                'Change those in plugin settings and try again.',
                 show=True,
                 show_copy_button=False
             )
@@ -915,8 +953,11 @@ class KoreaderAction(InterfaceAction):
 
             # Only get sync status if curr progress < 100 and status = reading or if curr_progress/status is not set yet
             metadata_status = metadata.get(status_key)
+            metadata_status_enum = metadata.get(status_key_enum)
             metadata_read_percent = metadata.get(read_percent_key)
-            if (metadata_status is None or metadata_status == "reading") and (metadata_read_percent is None or metadata_read_percent < 100):
+            if (metadata_read_percent is None or metadata_read_percent < 100) and \
+               ((metadata_status is None or metadata_status == reading_status_texts_reading) or \
+                (metadata_status_enum is None or metadata_status_enum == reading_status_texts_reading)):
                 try:
                     url = f'{CONFIG["progress_sync_url"]}/syncs/progress/{md5_value}'
                     request = Request(url, headers=headers)

--- a/action.py
+++ b/action.py
@@ -530,11 +530,9 @@ class KoreaderAction(InterfaceAction):
         status_key_enum = CONFIG['column_status_enum']
         if CONFIG['checkbox_no_sync_if_finished']:
             current_read_percent = metadata.get(read_percent_key)
-            current_status = metadata.get(status_key)
-            current_status_enum = metadata.get(status_key_enum)
+            current_status = metadata.get(status_key) or metadata.get(status_key_enum)
             if (current_read_percent is not None and current_read_percent >= 100) \
-                    or (current_status is not None and current_status == reading_status_texts_complete) \
-                    or (current_status_enum is not None and current_status_enum == reading_status_texts_complete):
+                    or (current_status is not None and current_status == reading_status_texts_complete):
                 debug_print(f'book {book_id} was already finished')
                 return OperationStatus.SKIP, {
                     'result': 'skipped, book already finished',
@@ -546,14 +544,10 @@ class KoreaderAction(InterfaceAction):
             new_status_enum = keys_values_to_update.get(status_key_enum)
             if not new_status or not new_status_enum:
                 new_read_percent = keys_values_to_update.get(read_percent_key)
-                current_status = metadata.get(status_key)
-                current_status_enum = metadata.get(status_key_enum)
-                if new_read_percent \
-                        and ((current_status is not None and current_status != reading_status_texts_abandoned) \
-                          or (current_status_enum is not None and current_status_enum != reading_status_texts_abandoned)):
+                current_status = metadata.get(status_key) or metadata.get(status_key_enum)
+                if new_read_percent and (current_status is not None and current_status != reading_status_texts_abandoned):
                     if new_read_percent > 0 and new_read_percent < 100 \
-                            and ((current_status is not None and current_status != reading_status_texts_reading) \
-                              or (current_status_enum is not None and current_status_enum != reading_status_texts_reading)):
+                            and (current_status is not None and current_status != reading_status_texts_reading):
                         if status_key:
                             debug_print(
                                 f'book {book_id} set column_status to {reading_status_texts_reading}')
@@ -565,9 +559,7 @@ class KoreaderAction(InterfaceAction):
                         status_bool_key = CONFIG['column_status_bool']
                         if status_bool_key:
                             keys_values_to_update[status_bool_key] = False
-                    elif new_read_percent >= 100 \
-                            and ((current_status is not None and current_status != reading_status_texts_complete) \
-                              or (current_status_enum is not None and current_status_enum != reading_status_texts_complete)):
+                    elif new_read_percent >= 100 and (current_status is not None and current_status != reading_status_texts_complete):
                         if status_key:
                             debug_print(
                                 f'book {book_id} set column_status to {reading_status_texts_complete}')
@@ -952,12 +944,10 @@ class KoreaderAction(InterfaceAction):
             title = metadata.get('title')
 
             # Only get sync status if curr progress < 100 and status = reading or if curr_progress/status is not set yet
-            metadata_status = metadata.get(status_key)
-            metadata_status_enum = metadata.get(status_key_enum)
+            metadata_status = metadata.get(status_key) or metadata.get(status_key_enum)
             metadata_read_percent = metadata.get(read_percent_key)
             if (metadata_read_percent is None or metadata_read_percent < 100) \
-                   and ((metadata_status is None or metadata_status == reading_status_texts_reading) \
-                     or (metadata_status_enum is None or metadata_status_enum == reading_status_texts_reading)):
+                    and (metadata_status is None or metadata_status == reading_status_texts_reading):
                 try:
                     url = f'{CONFIG["progress_sync_url"]}/syncs/progress/{md5_value}'
                     request = Request(url, headers=headers)

--- a/config.py
+++ b/config.py
@@ -117,6 +117,18 @@ CUSTOM_COLUMN_DEFAULTS = {
         'data_source': 'sidecar',
         'data_location': ['summary', 'status'],
     },
+    'column_status_enum': {
+        'column_heading': _("KOReader Book Status (Fixed Text)"),
+        'datatype': 'enumeration',
+        'description': _("Reading status of the book, either Finished, Reading, or On hold."),
+        'default_lookup_name': '#ko_status_enum',
+        'config_label': _('Reading status column (fixed text):'),
+        'config_tool_tip': _('A regular "Text" column to store the reading status of the\n'
+                             'book, as entered on the book status page ("Finished",\n'
+                             '"Reading", "On hold").'),
+        'data_source': 'sidecar',
+        'data_location': ['summary', 'status'],
+    },
     'column_status_bool': {
         'column_heading': _("KOReader Book Status Y/N"),
         'datatype': 'bool',
@@ -286,6 +298,9 @@ for this_column in CUSTOM_COLUMN_DEFAULTS:
     CONFIG.defaults[this_column] = ''
 for this_checkbox in CHECKBOXES:
     CONFIG.defaults[this_checkbox] = False
+CONFIG.defaults['reading_status_texts_reading'] = 'reading'
+CONFIG.defaults['reading_status_texts_complete'] = 'complete'
+CONFIG.defaults['reading_status_texts_abandoned'] = 'abandoned'
 CONFIG.defaults['progress_sync_url'] = 'https://sync.koreader.rocks:443'
 CONFIG.defaults['progress_sync_username'] = ''
 CONFIG.defaults['progress_sync_password'] = ''
@@ -350,6 +365,24 @@ class ConfigWidget(QWidget):  # https://doc.qt.io/qt-5/qwidget.html
                 CONFIG[config_name]
             )
 
+        # Add option to change reading status texts
+        layout.addWidget(QLabel('Set the reading status names for "Reading", "Completed" and "Abandoned" (case sensitive):'))
+        reading_status_texts_layout = QHBoxLayout()
+        reading_status_texts_layout.setAlignment(Qt.AlignLeft)
+        self.reading_status_texts_reading = QLineEdit(self)
+        self.reading_status_texts_reading.setText(CONFIG['reading_status_texts_reading'])
+        self.reading_status_texts_reading.setToolTip('Text to set to when book is being read')
+        reading_status_texts_layout.addWidget(self.reading_status_texts_reading)
+        self.reading_status_texts_complete = QLineEdit(self)
+        self.reading_status_texts_complete.setText(CONFIG['reading_status_texts_complete'])
+        self.reading_status_texts_complete.setToolTip('Text to set to when book is complete')
+        reading_status_texts_layout.addWidget(self.reading_status_texts_complete)
+        self.reading_status_texts_abandoned = QLineEdit(self)
+        self.reading_status_texts_abandoned.setText(CONFIG['reading_status_texts_abandoned'])
+        self.reading_status_texts_abandoned.setToolTip('Text to set to when book is abandoned')
+        reading_status_texts_layout.addWidget(self.reading_status_texts_abandoned)
+        layout.addLayout(reading_status_texts_layout)
+
         # Add custom checkboxes
         layout.addLayout(self.add_checkbox('checkbox_percent_read_100'))
         layout.addLayout(self.add_checkbox('checkbox_sync_if_more_recent'))
@@ -362,7 +395,7 @@ class ConfigWidget(QWidget):  # https://doc.qt.io/qt-5/qwidget.html
         ps_header_label = QLabel(
             "This plugin supports use of KOReader's built-in ProgressSync server to update reading progress and location without the device connected. "
             "You must have an MD5 column mapped and use Binary matching in KOReader's ProgressSync Settings (default).\n"
-            "You also need a reading progress column and status text column.\n"
+            "You also need a reading progress column and status text column (text or fixed text).\n"
             "This functionality can optionally be scheduled into a daily sync from within calibre. "
             "Enter scheduled time in military time, default is 4 AM local time. You must restart calibre after making changes to scheduled sync settings. "
         )
@@ -425,6 +458,11 @@ class ConfigWidget(QWidget):  # https://doc.qt.io/qt-5/qwidget.html
         CONFIG['scheduleSyncHour'] = self.schedule_hour_input.value()
         CONFIG['scheduleSyncMinute'] = self.schedule_minute_input.value()
         # NOTE: Server/Credentials are saved by the ProgressSyncPopup
+
+        # Save reading status texts
+        CONFIG['reading_status_texts_reading'] = self.reading_status_texts_reading.text()
+        CONFIG['reading_status_texts_complete'] = self.reading_status_texts_complete.text()
+        CONFIG['reading_status_texts_abandoned'] = self.reading_status_texts_abandoned.text()
 
         debug_print('new CONFIG = ', CONFIG)
         if needRestart and show_restart_warning('Changes have been made that require a restart to take effect.\nRestart now?'):


### PR DESCRIPTION
Hey,

I faced the issue that the current settings didn't fit into my workflow.
I am using a "fixed text" instead of "text" column for the status and I have different texts for them as well ("Reading" instead of "reading", "Finished" instead of "complete").

This PR adds options to freely configure these two things:
* Adds a "fixed text" column for status
* Requires either "text" or "fixed text" now (both works too)
* Adds option to set the status texts for each status (reading, complete, abandoned) freely, while the current ones are set as defaults

Only tested with koreader sync server, not with sidecar. But I didn't change any sidecar related logic (besides `update_metadata` but this should be unanimous.
(`sidecar_contents` status is still hardcoded to 'reading' and 'complete' since those are the values stored inside the sidecar)