### PR TITLE
[ProgressSync] Added column_device_name and _id for progress sync server

### DIFF
--- a/action.py
+++ b/action.py
@@ -937,15 +937,16 @@ class KoreaderAction(InterfaceAction):
 
                     # List of keys to check
                     ProgressSync_Columns = [
-                        'column_percent_read', 'column_percent_read_int', 'column_last_read_location', 'column_date_synced']
+                        'column_percent_read', 'column_percent_read_int', 'column_last_read_location', 'column_date_synced', 'column_device_name', 'column_device_id']
 
                     # Map of progress_data keys to match each config key
                     progress_mapping = {
                         'column_percent_read': progress_data['percentage'] if not CONFIG["checkbox_percent_read_100"] else progress_data['percentage']*100,
                         'column_percent_read_int': round(progress_data['percentage']*100),
                         'column_last_read_location': progress_data['progress'],
-                        'column_date_synced': datetime.fromtimestamp(progress_data['timestamp']/1000, tz=local_tz)
-                        # Device and Device ID could also be added
+                        'column_date_synced': datetime.fromtimestamp(progress_data['timestamp']/1000, tz=local_tz),
+                        'column_device_name': progress_data['device'],
+                        'column_device_id': progress_data['device_id']
                     }
                     # Change percentage to be human readable on summary screen
                     if CONFIG["checkbox_percent_read_100"]:

--- a/config.py
+++ b/config.py
@@ -211,6 +211,28 @@ CUSTOM_COLUMN_DEFAULTS = {
         'data_source': 'sidecar',
         'data_location': ['partial_md5_checksum'],
     },
+    'column_device_name': {
+        'column_heading': _("KOReader Device Name"),
+        'datatype': 'text',
+        'description': _("Last Synced Device Name from ProgressSync."),
+        'default_lookup_name': '#ko_device_name',
+        'config_label': _('ProgressSync Device Name:'),
+        'config_tool_tip': _('A regular "Text" column to store the last device name used\n'
+                             'to sync progress via ProgressSync.'),
+        'data_source': 'progresssync',
+        'data_location': ['device'],
+    },
+    'column_device_id': {
+        'column_heading': _("KOReader Device ID"),
+        'datatype': 'text',
+        'description': _("Last Synced Device ID from ProgressSync."),
+        'default_lookup_name': '#ko_device_id',
+        'config_label': _('ProgressSync Device ID:'),
+        'config_tool_tip': _('A regular "Text" column to store the last device id used\n'
+                             'to sync progress via ProgressSync.'),
+        'data_source': 'progresssync',
+        'data_location': ['device'],
+    },
     'column_date_synced': {
         'column_heading': _("Date KOReader Synced"),
         'datatype': 'datetime',


### PR DESCRIPTION
Implemented the remaining TODO in the comments to also map the device_name and device_id fields of the progress sync server.

This will use the latest name and id from which the progress is being pulled, overwriting existing data if different.