### PR TITLE
[Fix] Allow plugin to be placed in the optional second toolbar

### DIFF
--- a/action.py
+++ b/action.py
@@ -181,7 +181,7 @@ class KoreaderAction(InterfaceAction):
     action_menu_clone_qaction = 'Sync from KOReader'
     dont_add_to = frozenset(
         [
-            'context-menu', 'context-menu-device', 'toolbar-child', 'menubar',
+            'context-menu', 'context-menu-device', 'menubar',
             'menubar-device', 'context-menu-cover-browser',
             'context-menu-split']
     )


### PR DESCRIPTION
Fixes #110 

No idea why this was prevent? I tested it and it works just as well from the optional toolbar as from the main one.