### PR TITLE
Don't handle three different fields in the same try...except in get_sidecar

### DIFF
--- a/action.py
+++ b/action.py
@@ -449,9 +449,15 @@ class KoreaderAction(InterfaceAction):
             try:
                 parsed_contents['calculated'][
                 'date_synced'] = datetime.now().replace(tzinfo=local_tz)
+            except:
+                pass
+            try:
                 parsed_contents['calculated'][
                     'date_status_changed'] = datetime.strptime(
                     parsed_contents['summary']['modified'], "%Y-%m-%d").replace(tzinfo=local_tz)
+            except:
+                pass
+            try:
                 parsed_contents['calculated'][
                     'date_sidecar_modified'] = datetime.fromtimestamp(
                     os.path.getmtime(path)).replace(tzinfo=local_tz)


### PR DESCRIPTION
I was trying to sync the date_sidecar_modified field. It wasn't working -- just writing nothing into my column.

This was because there's a `try` block here that does three things in it. Either the date_synced or date_status_changed part was throwing an exception. This caused it to not set date_sidecar_modified. I never saw what the exception actually was, since it gets swallowed.

I changed this to have three `try` blocks for the three different operations, and this resolves my problem. 

(I don't think swallowing the exception here is a very good idea in the first place but I'll leave that for you to decide if there's a reasonable way to helpfully report errors here to the user)