### PR TITLE
Add checkbox to skip ssl verification

### DIFF
--- a/action.py
+++ b/action.py
@@ -14,6 +14,7 @@ import time
 
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
+import ssl
 
 from PyQt5.Qt import (
     QUrl,
@@ -907,6 +908,13 @@ class KoreaderAction(InterfaceAction):
             'User-Agent': f'CalibreKOReaderSync/{self.version}'
         }
 
+        # Create SSL context based on user preference
+        ssl_context = ssl.create_default_context()
+        if CONFIG['checkbox_skip_ssl_verification']:
+            # Skip SSL verification for custom servers with self-signed certificates
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
         for book_id in books_with_md5:
             metadata = db.get_metadata(book_id)
             md5_value = metadata.get(md5_column)
@@ -920,7 +928,7 @@ class KoreaderAction(InterfaceAction):
                 try:
                     url = f'{CONFIG["progress_sync_url"]}/syncs/progress/{md5_value}'
                     request = Request(url, headers=headers)
-                    with urlopen(request, timeout=20) as response:
+                    with urlopen(request, timeout=20, context=ssl_context) as response:
                         response_data = response.read()
                         if response_data == b'{}':
                             results.append({

--- a/config.py
+++ b/config.py
@@ -279,6 +279,12 @@ CHECKBOXES = {  # Each entry in the below dict is keyed with config_name
         'config_tool_tip': 'Enable daily sync of reading progress and location using \n'
         'KOReader\'s ProgressSync server.',
     },
+    'checkbox_skip_ssl_verification': {
+        'config_label': 'Skip SSL certificate verification for ProgressSync',
+        'config_tool_tip': 'Disable SSL certificate verification when connecting to ProgressSync server.\n'
+        'Enable this if you use a custom server with self-signed certificates or IP addresses.\n'
+        'Warning: This reduces security. Only use with trusted servers.',
+    },
 }
 
 CONFIG = JSONConfig(os.path.join('plugins', 'KOReader Sync.json'))
@@ -286,6 +292,8 @@ for this_column in CUSTOM_COLUMN_DEFAULTS:
     CONFIG.defaults[this_column] = ''
 for this_checkbox in CHECKBOXES:
     CONFIG.defaults[this_checkbox] = False
+
+CONFIG.defaults['checkbox_skip_ssl_verification'] = False
 CONFIG.defaults['progress_sync_url'] = 'https://sync.koreader.rocks:443'
 CONFIG.defaults['progress_sync_username'] = ''
 CONFIG.defaults['progress_sync_password'] = ''
@@ -368,6 +376,9 @@ class ConfigWidget(QWidget):  # https://doc.qt.io/qt-5/qwidget.html
         )
         ps_header_label.setWordWrap(True)
         layout.addWidget(ps_header_label)
+
+        # Add SSL verification checkbox
+        layout.addLayout(self.add_checkbox('checkbox_skip_ssl_verification'))
 
         # Add scheduled sync options
         scheduled_sync_layout = QHBoxLayout()


### PR DESCRIPTION
This PR fixes #89. 
Using https with an IP address (e.g. from a self-hosted sync-server) causes an SSL certificate verification issue. 
I added a checkbox, which allows users to skip certificate verification. 