### PR TITLE
Fix plugin removal and syntax warnings (#113)

### DIFF
--- a/action.py
+++ b/action.py
@@ -145,7 +145,7 @@ def parse_sidecar_lua(sidecar_lua):
     )
 
     try:
-        clean_lua = re.sub('^[^{]*', '', sidecar_lua).strip()
+        clean_lua = re.sub(r'^[^{]*', '', sidecar_lua).strip()
         decoded_lua = lua.decode(clean_lua)
     except:
         debug_print('could not decode sidecar_lua')
@@ -186,7 +186,7 @@ class KoreaderAction(InterfaceAction):
             'menubar-device', 'context-menu-cover-browser',
             'context-menu-split']
     )
-    dont_remove_from = InterfaceAction.all_locations - dont_add_to
+    dont_remove_from = frozenset()
     action_type = 'current'
 
     def genesis(self):

--- a/slpp.py
+++ b/slpp.py
@@ -55,8 +55,8 @@ class SLPP(object):
         self.at = 0
         self.len = 0
         self.depth = 0
-        self.space = re.compile('\s', re.M)
-        self.alnum = re.compile('\w', re.M)
+        self.space = re.compile(r'\s', re.M)
+        self.alnum = re.compile(r'\w', re.M)
         self.newline = '\n'
         self.tab = '\t'
 


### PR DESCRIPTION
- Set dont_remove_from to frozenset to allow plugin removal from toolbar
- Use raw strings for regex patterns to fix 'invalid escape sequence' warnings