### PR TITLE
Add security policy for responsible vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+At koreader-calibre-plugin, we take security seriously and appreciate your efforts to disclose vulnerabilities responsibly. If you discover a security issue, please report it as soon as possible.
+
+**Please do not create public issues for security-related reports.**
+
+- To report a security issue, please use the GitHub Security Advisories tab to [**open a draft security advisory**](https://github.com/kyxap/koreader-calibre-plugin/security/advisories/new).
+- Include a detailed description of the issue, steps to reproduce, potential impact, and any possible mitigations.
+- If applicable, please also attach proof-of-concept code, logs, or screenshots.
+
+---
+
+## Supported Versions
+
+We aim to support the latest released version and one previous minor release.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest (`main`) | ✅ Supported |
+| Previous minor | ✅ Supported |
+| Older versions | ❌ Not supported |
+
+If you are using an unsupported version, we strongly recommend updating to the latest release to receive security fixes.
+
+---
+
+## Disclosure Policy
+
+- We follow a **coordinated disclosure** approach.
+- We will not publicly disclose vulnerabilities until a fix has been developed and released.
+- We ask reporters to keep vulnerability details confidential until remediation is complete.
+- Credit will be given to researchers who responsibly disclose vulnerabilities, if requested.
+
+---
+
+## Acknowledgements
+
+We greatly appreciate contributions from the security community and strive to recognize all researchers who help keep koreader-calibre-plugin safe.


### PR DESCRIPTION
Hi maintainers,

I believe I may have identified a potential security-related issue in this project. Before sharing any details, I wanted to make sure there is a clear private channel for responsible vulnerability disclosure.

Since I could not find a SECURITY.md policy in the repository, this pull request proposes adding one to make the disclosure process clearer for security researchers.

If there is already a preferred contact method or process, I’d be happy to update the document accordingly.

Thanks for your time.