### PR TITLE
Fix ProgressSync last-synced date showing 22 Jan 1970

### DIFF
--- a/action.py
+++ b/action.py
@@ -1065,7 +1065,7 @@ class KoreaderAction(InterfaceAction):
                         'column_percent_read': progress_data['percentage'] if not CONFIG["checkbox_percent_read_100"] else progress_data['percentage']*100,
                         'column_percent_read_int': round(progress_data['percentage']*100),
                         'column_last_read_location': progress_data['progress'],
-                        'column_date_synced': datetime.fromtimestamp(progress_data['timestamp']/1000, tz=local_tz),
+                        'column_date_synced': datetime.fromtimestamp(progress_data['timestamp'], tz=local_tz),
                         'column_device_name': progress_data['device'],
                         'column_device_id': progress_data['device_id']
                     }


### PR DESCRIPTION
## Summary

`column_date_synced` was showing dates around 22 Jan 1970 instead of the real sync time.

`progress_data['timestamp']` comes directly from the KOReader sync server's `GET /syncs/progress/:document` response. The reference server implementation (`koreader/koreader-sync-server`, `syncs_controller.lua`) stores this via Lua's `os.time()`, i.e. plain Unix **seconds**:

```lua
local timestamp = os.time()
...
redis:hmset(key, { ..., [self.timestamp_field] = timestamp })
```

`action.py` was dividing that value by 1000 before calling `datetime.fromtimestamp()`, which is the correct conversion for **milliseconds**, not seconds:

```python
datetime.fromtimestamp(progress_data['timestamp']/1000, tz=local_tz)
```

Today's real epoch time is roughly 1.78 billion seconds. Dividing that by 1000 gives ~1.78 million seconds, which lands about 20 days after the Unix epoch — displayed as 22 Jan 1970. This reproduces consistently regardless of which KOReader client wrote the progress, since the server always uses its own current time on write and this plugin's date math is what mangles it afterward.

## Fix

Removed the `/1000` — `progress_data['timestamp']` is already in seconds, which is what `datetime.fromtimestamp()` expects.

## Test plan

- `make test` (via `pytest tests/`): 14/16 pass; the 2 pre-existing failures (`test_version_match`, `test_version_tuple_match`) are unrelated version-string sync checks that also fail on unmodified `develop` HEAD.
- `make lint` (via `pylint`): 9.68/10 (above the 9.5 threshold), no new warnings on the changed line.
- Confirmed against the reference sync server's source that `timestamp` is written as Unix seconds, not milliseconds.