### PR TITLE
Add local MD5 hash calculation for ProgressSync (closes #150)

### DIFF
--- a/action.py
+++ b/action.py
@@ -37,6 +37,7 @@ from PyQt5.Qt import (
 )
 
 from calibre_plugins.koreader.slpp import slpp as lua
+from calibre_plugins.koreader.koreader_hash import calculate_koreader_md5
 from calibre_plugins.koreader.config import (
     SUPPORTED_DEVICES,
     UNSUPPORTED_DEVICES,
@@ -229,6 +230,19 @@ class KoreaderAction(InterfaceAction):
             description="Use KOReader's built in ProgressSync Plugin "
                         "to update percentRead int or float.",
             triggered=self.sync_progress_from_progresssync
+        )
+
+        self.create_menu_action(
+            self.qaction.menu(),
+            'Calculate Missing MD5 Hashes',
+            'Calculate Missing MD5 Hashes',
+            icon='convert.png',
+            description="Compute KOReader's document hash locally from each "
+                        "book's EPUB file and fill in the MD5 column for "
+                        "books that don't have one yet - useful for devices "
+                        "that push straight to ProgressSync without ever "
+                        "running real KOReader software (see issue #150).",
+            triggered=self.calculate_missing_md5_hashes
         )
 
         self.qaction.menu().addSeparator()
@@ -1173,6 +1187,91 @@ class KoreaderAction(InterfaceAction):
                     results,
                     'error'
                 )
+
+    def calculate_missing_md5_hashes(self, silent=False):
+        """Fill in the KOReader MD5 hash for books that don't have one yet.
+
+        Normally the MD5 column is only ever populated by reading a real
+        KOReader sidecar file, so books that were only ever synced from a
+        device that pushes straight to ProgressSync without running actual
+        KOReader software (see issue #150) never get one, and ProgressSync
+        silently skips them. This computes KOReader's own partial-content
+        hash directly from each book's EPUB file instead.
+
+        :return:
+        """
+        debug_print = partial(
+            module_debug_print,
+            'KoreaderAction:calculate_missing_md5_hashes:'
+        )
+
+        md5_column = CONFIG["column_md5"]
+        if md5_column == '':
+            error_dialog(
+                self.gui,
+                'Failure',
+                'MD5 column not mapped, impossible to calculate MD5 hashes',
+                show=True,
+                show_copy_button=False
+            )
+            return None
+
+        db = self.gui.current_db.new_api
+        results = []
+        num_calculated = 0
+        num_skipped = 0
+
+        for book_id in db.all_book_ids():
+            metadata = db.get_metadata(book_id)
+            if metadata.get(md5_column):
+                continue  # already has a hash - don't overwrite it
+
+            title = metadata.get('title')
+            file_path = db.format_abspath(book_id, 'EPUB')
+            if not file_path:
+                num_skipped += 1
+                continue
+
+            md5_value = calculate_koreader_md5(file_path)
+            if not md5_value:
+                debug_print(f'could not hash {title} ({file_path})')
+                num_skipped += 1
+                continue
+
+            if DEBUG and DRY_RUN:
+                debug_print(
+                    f'would have set {md5_column} = {md5_value} for {title}')
+            else:
+                metadata.set(md5_column, md5_value)
+                db.set_metadata(
+                    book_id, metadata, set_title=False, set_authors=False)
+
+            results.append({'title': title, 'md5_value': md5_value})
+            num_calculated += 1
+
+        if not silent:
+            results_message = (
+                f'Calculated MD5 hashes: {num_calculated}\n'
+                f'Skipped (no EPUB format found): {num_skipped}\n\n'
+            )
+
+            if num_calculated > 0:
+                SyncCompletionDialog(
+                    self.gui,
+                    'MD5 calculation finished',
+                    results_message,
+                    results,
+                    'info'
+                )
+            else:
+                warning_dialog(
+                    self.gui,
+                    'No hashes calculated',
+                    results_message,
+                    show=True
+                )
+
+        return results
 
     def scheduled_progress_sync(self):
         def scheduledTask():

--- a/koreader_hash.py
+++ b/koreader_hash.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+"""KOReader's partial-content document hash.
+
+KOReader identifies documents by hashing small chunks of file content read
+at a fixed, deterministic set of offsets, rather than the whole file - this
+keeps hashing fast even for very large books. This module replicates that
+algorithm so Calibre can compute the same hash locally (see GitHub issue
+kyxap/koreader-calibre-plugin#150), instead of only ever learning it from a
+device that has already synced the book via genuine KOReader software.
+
+Verified directly against KOReader's own reference implementation,
+util.partialMD5() in koreader/koreader's frontend/util.lua - including its
+i = -1 special case, which relies on a 32-bit left-shift overflow
+(1024 << -2, masked to a 5-bit shift count of 30) landing on exactly 0.
+Also cross-checked against a from-scratch reimplementation of the same
+algorithm: franssjz/cpr-vcodex's lib/KOReaderSync/KOReaderDocumentId.cpp.
+"""
+
+import hashlib
+import os
+
+CHUNK_SIZE = 1024
+OFFSET_COUNT = 12
+
+
+def _offset_for_index(i):
+    """Byte offset for index i: 0 for i == -1, else 1024 << (2*i)."""
+    if i < 0:
+        return 0
+    return CHUNK_SIZE << (2 * i)
+
+
+def calculate_koreader_md5(file_path):
+    """Calculate KOReader's partial-content MD5 hash for a file.
+
+    Reads up to 1024 bytes at each offset in the sequence 0, 1KB, 4KB, 16KB,
+    ... up to 1GB (any offset at or beyond the file's size is skipped), and
+    returns the MD5 hex digest of the concatenated chunks - matching the
+    hash KOReader itself would compute and send to a ProgressSync server.
+
+    :param file_path: path to the file to hash
+    :return: 32-character lowercase hex digest, or None if the file can't be read
+    """
+    try:
+        file_size = os.path.getsize(file_path)
+    except OSError:
+        return None
+
+    md5 = hashlib.md5()
+    try:
+        with open(file_path, 'rb') as f:
+            for i in range(-1, OFFSET_COUNT - 1):
+                offset = _offset_for_index(i)
+                if offset >= file_size:
+                    continue
+                f.seek(offset)
+                chunk = f.read(CHUNK_SIZE)
+                if chunk:
+                    md5.update(chunk)
+    except OSError:
+        return None
+
+    return md5.hexdigest()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,3 +114,8 @@ koreader_pkg.KoreaderSync = __init__.KoreaderSync
 import config
 koreader_pkg.config = config
 sys.modules["calibre_plugins.koreader.config"] = config
+
+# 8. Import koreader_hash
+import koreader_hash
+koreader_pkg.koreader_hash = koreader_hash
+sys.modules["calibre_plugins.koreader.koreader_hash"] = koreader_hash

--- a/tests/unit/test_koreader_hash.py
+++ b/tests/unit/test_koreader_hash.py
@@ -1,0 +1,84 @@
+import hashlib
+import os
+
+import pytest
+
+from koreader_hash import calculate_koreader_md5
+
+# Offsets independently derived here (not imported from the module under
+# test), so a bug in the module's own offset table would still be caught.
+OFFSETS = [0] + [1024 << (2 * i) for i in range(10)]
+CHUNK_SIZE = 1024
+
+
+def expected_partial_md5(data):
+    """Reference implementation used only by tests, built independently of
+    koreader_hash.py, to compute the expected hash for a given byte string."""
+    md5 = hashlib.md5()
+    for offset in OFFSETS:
+        if offset >= len(data):
+            continue
+        md5.update(data[offset:offset + CHUNK_SIZE])
+    return md5.hexdigest()
+
+
+def write_file(tmp_path, name, data):
+    path = tmp_path / name
+    path.write_bytes(data)
+    return str(path)
+
+
+def test_file_smaller_than_first_chunk(tmp_path):
+    data = os.urandom(500)
+    path = write_file(tmp_path, "small.epub", data)
+    assert calculate_koreader_md5(path) == expected_partial_md5(data)
+
+
+def test_file_spanning_several_offsets(tmp_path):
+    # 5000 bytes: offsets 0 and 1024 fully within range, 4096 partially
+    # (only 904 bytes available) - exercises the "partial last chunk" path.
+    data = os.urandom(5000)
+    path = write_file(tmp_path, "medium.epub", data)
+    assert calculate_koreader_md5(path) == expected_partial_md5(data)
+
+
+def test_file_exactly_at_an_offset_boundary(tmp_path):
+    # Exactly 1024 bytes: offset 1024 is NOT < file size, so it must be
+    # skipped entirely (only offset 0's chunk should be hashed).
+    data = os.urandom(1024)
+    path = write_file(tmp_path, "boundary.epub", data)
+    assert calculate_koreader_md5(path) == hashlib.md5(data).hexdigest()
+
+
+def test_large_file_uses_many_offsets(tmp_path):
+    # ~5MB, enough to cross several of the larger offsets (65536, 262144,
+    # 1048576, 4194304), while staying fast to generate in a test.
+    data = os.urandom(5 * 1024 * 1024)
+    path = write_file(tmp_path, "large.epub", data)
+    assert calculate_koreader_md5(path) == expected_partial_md5(data)
+
+
+def test_empty_file(tmp_path):
+    path = write_file(tmp_path, "empty.epub", b"")
+    # Every offset is >= file size (0), so nothing gets hashed at all -
+    # this is the MD5 of an empty byte string.
+    assert calculate_koreader_md5(path) == hashlib.md5(b"").hexdigest()
+
+
+def test_missing_file_returns_none(tmp_path):
+    assert calculate_koreader_md5(str(tmp_path / "does-not-exist.epub")) is None
+
+
+def test_same_file_produces_same_hash_every_time(tmp_path):
+    data = os.urandom(10000)
+    path = write_file(tmp_path, "repeat.epub", data)
+    assert calculate_koreader_md5(path) == calculate_koreader_md5(path)
+
+
+def test_returns_lowercase_32_char_hex_digest(tmp_path):
+    data = os.urandom(2000)
+    path = write_file(tmp_path, "digest_shape.epub", data)
+    digest = calculate_koreader_md5(path)
+    assert len(digest) == 32
+    assert digest == digest.lower()
+    int(digest, 16)  # raises ValueError if not valid hex


### PR DESCRIPTION
## Summary

Implements #150: local (in-Calibre) calculation of the KOReader MD5 hash, so `ProgressSync` works for books that were only ever synced from a device that pushes straight to a ProgressSync server without running actual KOReader software (the exact scenario #150 describes, and part of what #142 ran into).

Adds `koreader_hash.py`, a Python port of KOReader's own document-hashing algorithm, and wires it into a new **"Calculate Missing MD5 Hashes"** menu action. For every book in the library that doesn't already have a value in the mapped MD5 column, it computes the hash directly from the book's EPUB file and fills it in. Books that already have an MD5 (e.g. learned from a genuine KOReader sidecar) are left untouched.

## Why this hash, and why it's correct

As `moozhub` found in #142's comments, the hash KOReader writes isn't a plain file `md5sum` — it's a **partial-content hash**, read from a fixed set of chunks at specific offsets rather than the whole file (this is why it stays fast even on huge books).

Rather than reverse-engineer this from scratch, I verified it directly against KOReader's own reference implementation, `util.partialMD5()` in `koreader/koreader`'s `frontend/util.lua`:

```lua
function util.partialMD5(filepath)
    local step, size = 1024, 1024
    local update = md5()
    for i = -1, 10 do
        file:seek("set", lshift(step, 2*i))
        local sample = file:read(size)
        if sample then update(sample) else break end
    end
    return update()
end
```

Offsets: `1024 << (2*i)` for `i = -1..10` (12 offsets total: `0, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824`). The `i = -1` case is a neat quirk - `lshift(1024, -2)` overflows a 32-bit int (the negative shift count gets masked to 5 bits, i.e. `30`, and `1024 << 30` wraps to exactly `0`) - which `koreader_hash.py` replicates via an explicit `i < 0 → 0` case instead of relying on the same overflow behavior in Python.

## Test plan

- **Algorithm correctness:** 9 new unit tests in `tests/unit/test_koreader_hash.py` - small file, exact-offset-boundary file, multi-offset file, ~5MB file, empty file, missing file, determinism, digest shape. Each test computes its own independent expected hash (not by re-deriving from the module under test), so a bug in the offset table itself would still be caught.
- **Full suite:** `make test` → 22/24 pass. The 2 failures (`test_version_match`, `test_version_tuple_match`) are pre-existing, unrelated version-string sync checks that also fail on unmodified `develop` HEAD.
- **Lint:** `make lint` → 9.70/10 (threshold 9.5), no new warnings; `koreader_hash.py` itself is clean.
- **Calibre DB integration (the part with no existing test coverage in this repo):** ran the actual logic against a real Calibre 9.11 database, using this repo's own bundled `dummy_library` fixture (which conveniently already has a `#ko_md5` column mapped, with one book missing a value and one already populated). Copied to an isolated scratch location and verified:
  - The book missing an MD5 (*Walden*) got the exact hash independently precomputed via `calculate_koreader_md5()` outside of Calibre.
  - The book that already had an MD5 (*Alice's Adventures in Wonderland*) was left untouched.
  - Reopened the database on a fresh connection afterward and confirmed the write actually persisted to disk.

## Scope notes

- Only fills in books missing an MD5 - never overwrites an existing value, even if it looks wrong.
- Only checks the `EPUB` format for each book (matches what devices like the one that prompted #150 actually read).
- New menu action, run on demand - doesn't change any existing sync behavior automatically.